### PR TITLE
bump ipfs hash for v4.1.1 zcash artifacts

### DIFF
--- a/README-ipfs.sh
+++ b/README-ipfs.sh
@@ -42,19 +42,25 @@ kubectl get taskruns -w
 # Use a wait command for scripting
 kubectl wait --for=condition=Succeeded taskruns -l import=zcash-snapshot-ipfs  --timeout=6000s
 
-## Taking forever? Add a peer that has these CIDs
-# Expose the port for IPFS API locally
-# kubectl port-forward svc/ipfs-cache 5001:5001
+## Taking forever? Depending on you geo-location it might be helpful to add some peers:
+#  Expose the port for IPFS API locally
+#  (You MUST wait for the initial pods to go from `Pending` to 
+# `Running` before issueing below command(wait ~30 seconds), after `kubectl get taskruns -w`)
+#
+# kubectl port-forward svc/ipfs-cache 5002:5001 &
+# ipfs --api=/ip4/127.0.0.1/tcp/5002 swarm connect /dnsaddr/nyc1-1.hostnodes.pinata.cloud
+# ipfs --api=/ip4/127.0.0.1/tcp/5002 swarm connect /dnsaddr/nyc1-2.hostnodes.pinata.cloud
+# ipfs --api=/ip4/127.0.0.1/tcp/5002 swarm connect /dnsaddr/nyc1-3.hostnodes.pinata.cloud
 
 # Download the ipfs binary from https://dist.ipfs.io/#go-ipfs
 # Use it to connect the ipfs-cache to a peer (this is one I set up)
 # If you change port numbers, use the ipfs --api flag to specify the endpoint
 # ipfs swarm connect  /ip4/192.241.134.110/tcp/4001/p2p/QmVgxJPDHLXZ3rTiuFHjByDbGCfEDSE5EJPTwYwanxUv3e 
 
-# Checking on status
-
 ## Open a port to the Grafana dashboard
-kubectl port-forward svc/monitoring 0.0.0.0:3000:3000 &
+kubectl port-forward svc/monitoring 3000:3000 &
+
+Browse to http://localhost:3000/d/mIrc97CCz/zcash-testnet-in-a-box
 
 # View the logs of BOTH deployed miners
 kubectl logs -l "app=zcash-with-exporter" -c zcashd-script -f
@@ -62,3 +68,5 @@ kubectl logs -l "app=zcash-with-exporter" -c zcashd-script -f
 
 # View the peering process for errors
 kubectl logs -l "app=zcashd-peers"
+
+# You can also make use of Lens: https://github.com/zcash-hackworks/zcash-testnet-in-a-box#using-lens-ide

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 TNB (testnet-in-a-box) will deploy a collection of monitored and peered zcashd instances to a Kubernetes cluster.
 
 A deployment requires 2 tar archives:
-- An archive of binaries from a TNB build (zcashd, zcash-cli, zcash-gtest, zcash-tx) see the task for more info: [./tekton/tasks/build-binary-tnb.yml](./tekton/tasks/build-binary-tnb.yml)
-- An archive of a block snapshot from the regular testnet, see the task for more info: [./tekton/tasks/snapshot-gcp.yml](./tekton/tasks/snapshot-gcp.yml)
+- An archive of binaries from a TNB build (zcashd, zcash-cli, zcash-gtest, zcash-tx) see the task for more info: [./docs/BUILD-zcashd-tnb-artifacts-ipfs.md](./docs/BUILD-zcashd-tnb-artifacts-ipfs.md)
+- An archive of a block snapshot from the regular testnet, see the task for more info: [./bases/tekton/tasks/snapshot-gcp.yml ](./bases/tekton/tasks/snapshot-gcp.yml)
 
 The versions and source of these archives is defined in `deploy/configmaps-tnb.yml`
 
@@ -24,7 +24,7 @@ data:
 ## Deployment
 
 Install [kind](https://kind.sigs.k8s.io/docs/user/quick-start/)  
-See [./README.sh](./README.sh)
+See [./README-ipfs.sh](./README-ipfs.sh)
 
 (Important note: As of 7-30-2020, please do not run README.sh as a script. Instead copy/paste commands into terminal.)
 

--- a/bases/deploy/configmaps-tnb.yml
+++ b/bases/deploy/configmaps-tnb.yml
@@ -5,10 +5,10 @@ metadata:
   name: zcash-tnb-bundle
 data:
   ARCHIVE_NAME: zcashd-tnb-artifacts-d058568.tgz
-  ARCHIVE_HTTP_SRC: "https://gateway.pinata.cloud/ipfs/QmWwGVqBkWHFd6AqYZSsZZG4tQ9AoiQAG2i9pGoqGp2Mhp"
+  ARCHIVE_HTTP_SRC: "https://gateway.pinata.cloud/ipfs/Qmf66w7WV6QB8LWnZaz1G9GypCMCbky1p6fbx9DSDJG8XJ"
   ARTIFACTS_NAME: zcashd-tnb-artifacts-d058568.tgz
-  ARTIFACTS_IPFSCID: QmWwGVqBkWHFd6AqYZSsZZG4tQ9AoiQAG2i9pGoqGp2Mhp
-  ARTIFACTS_HTTP_SRC: "https://gateway.pinata.cloud/ipfs/QmWwGVqBkWHFd6AqYZSsZZG4tQ9AoiQAG2i9pGoqGp2Mhp"
+  ARTIFACTS_IPFSCID: Qmf66w7WV6QB8LWnZaz1G9GypCMCbky1p6fbx9DSDJG8XJ
+  ARTIFACTS_HTTP_SRC: "https://gateway.pinata.cloud/ipfs/Qmf66w7WV6QB8LWnZaz1G9GypCMCbky1p6fbx9DSDJG8XJ"
   ZCASH_PARAMS_IPFSCID: QmUSFo5zgPPXXejidzFWZcxVyF3AJH6Pr9br6Xisdww1r1
   SNAPSHOT_NAME: zcash-testnet-miner-1014515.tgz
   SNAPSHOT_IPFSCID: QmYj6AN8WziHikUjjoYTS1bGESTQkzXoMyzRKpa1H5gYv5

--- a/bases/deploy/configmaps-tnb.yml
+++ b/bases/deploy/configmaps-tnb.yml
@@ -4,11 +4,11 @@ kind: ConfigMap
 metadata:
   name: zcash-tnb-bundle
 data:
-  ARCHIVE_NAME: zcashd-tnb-artifacts-d058568.tgz
-  ARCHIVE_HTTP_SRC: "https://gateway.pinata.cloud/ipfs/QmRwNMJuJPuPse9eXPv2WHaQ17CkZZyNeGzZhicaxztjGx"
-  ARTIFACTS_NAME: zcashd-tnb-artifacts-d058568.tgz
-  ARTIFACTS_IPFSCID: QmRwNMJuJPuPse9eXPv2WHaQ17CkZZyNeGzZhicaxztjGx
-  ARTIFACTS_HTTP_SRC: "https://gateway.pinata.cloud/ipfs/QmRwNMJuJPuPse9eXPv2WHaQ17CkZZyNeGzZhicaxztjGx"
+  ARCHIVE_NAME: zcashd-tnb-artifacts-6d85686.tgz
+  ARCHIVE_HTTP_SRC: "https://gateway.pinata.cloud/ipfs/QmQXeLrPo1cWbjoLdMdwCHjynmFiBUSqLhMSUTSZUzZMQR"
+  ARTIFACTS_NAME: zcashd-tnb-artifacts-6d85686.tgz
+  ARTIFACTS_IPFSCID: QmQXeLrPo1cWbjoLdMdwCHjynmFiBUSqLhMSUTSZUzZMQR
+  ARTIFACTS_HTTP_SRC: "https://gateway.pinata.cloud/ipfs/QmQXeLrPo1cWbjoLdMdwCHjynmFiBUSqLhMSUTSZUzZMQR"
   ZCASH_PARAMS_IPFSCID: QmUSFo5zgPPXXejidzFWZcxVyF3AJH6Pr9br6Xisdww1r1
   SNAPSHOT_NAME: zcash-testnet-miner-1014515.tgz
   SNAPSHOT_IPFSCID: QmYj6AN8WziHikUjjoYTS1bGESTQkzXoMyzRKpa1H5gYv5

--- a/bases/deploy/configmaps-tnb.yml
+++ b/bases/deploy/configmaps-tnb.yml
@@ -5,10 +5,10 @@ metadata:
   name: zcash-tnb-bundle
 data:
   ARCHIVE_NAME: zcashd-tnb-artifacts-d058568.tgz
-  ARCHIVE_HTTP_SRC: "https://gateway.pinata.cloud/ipfs/Qmf66w7WV6QB8LWnZaz1G9GypCMCbky1p6fbx9DSDJG8XJ"
+  ARCHIVE_HTTP_SRC: "https://gateway.pinata.cloud/ipfs/QmRwNMJuJPuPse9eXPv2WHaQ17CkZZyNeGzZhicaxztjGx"
   ARTIFACTS_NAME: zcashd-tnb-artifacts-d058568.tgz
-  ARTIFACTS_IPFSCID: Qmf66w7WV6QB8LWnZaz1G9GypCMCbky1p6fbx9DSDJG8XJ
-  ARTIFACTS_HTTP_SRC: "https://gateway.pinata.cloud/ipfs/Qmf66w7WV6QB8LWnZaz1G9GypCMCbky1p6fbx9DSDJG8XJ"
+  ARTIFACTS_IPFSCID: QmRwNMJuJPuPse9eXPv2WHaQ17CkZZyNeGzZhicaxztjGx
+  ARTIFACTS_HTTP_SRC: "https://gateway.pinata.cloud/ipfs/QmRwNMJuJPuPse9eXPv2WHaQ17CkZZyNeGzZhicaxztjGx"
   ZCASH_PARAMS_IPFSCID: QmUSFo5zgPPXXejidzFWZcxVyF3AJH6Pr9br6Xisdww1r1
   SNAPSHOT_NAME: zcash-testnet-miner-1014515.tgz
   SNAPSHOT_IPFSCID: QmYj6AN8WziHikUjjoYTS1bGESTQkzXoMyzRKpa1H5gYv5

--- a/bases/deploy/configmaps-tnb.yml
+++ b/bases/deploy/configmaps-tnb.yml
@@ -10,9 +10,9 @@ data:
   ARTIFACTS_IPFSCID: QmQXeLrPo1cWbjoLdMdwCHjynmFiBUSqLhMSUTSZUzZMQR
   ARTIFACTS_HTTP_SRC: "https://gateway.pinata.cloud/ipfs/QmQXeLrPo1cWbjoLdMdwCHjynmFiBUSqLhMSUTSZUzZMQR"
   ZCASH_PARAMS_IPFSCID: QmUSFo5zgPPXXejidzFWZcxVyF3AJH6Pr9br6Xisdww1r1
-  SNAPSHOT_NAME: zcash-testnet-miner-1014515.tgz
-  SNAPSHOT_IPFSCID: QmYj6AN8WziHikUjjoYTS1bGESTQkzXoMyzRKpa1H5gYv5
-  SNAPSHOT_HTTP_SRC: "https://gateway.pinata.cloud/ipfs/QmYj6AN8WziHikUjjoYTS1bGESTQkzXoMyzRKpa1H5gYv5"
+  SNAPSHOT_NAME: zcash-testnet-miner-1199334.tgz
+  SNAPSHOT_IPFSCID: QmU51qV1efNJtZKKnHp71TWpkdMBpYfSsYhWLmdNj3BNsd
+  SNAPSHOT_HTTP_SRC: "https://gateway.pinata.cloud/ipfs/QmU51qV1efNJtZKKnHp71TWpkdMBpYfSsYhWLmdNj3BNsd"
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/docs/BUILD-zcashd-tnb-artifacts-ipfs.md
+++ b/docs/BUILD-zcashd-tnb-artifacts-ipfs.md
@@ -29,13 +29,16 @@ If no git resources are defined, relax. You just need to provide a "friendly nam
 For the rest of the prompts, the defaults should be fine.
 ```
 $ tkn tasks start zcashd-build-tnb
-? Choose the git resource to use for source:  [Use arrows to move, type to filter]
-> zcash (https://github.com/zcash/zcash.git#v4.1.0)
-  create new "git" resource
+Please create a new "git" resource for pipeline resource "source"
+? Enter a name for a pipeline resource : zc
+? Enter a value for url :  https://github.com/zcash/zcash.git
+? Enter a value for revision :  v4.1.1
+New git resource "zc" has been created
 ? Value for param `JOBS` of type `string`? (Default is `8`) 8
 ? Value for param `ipfs-api-service` of type `string`? (Default is `/dns/ipfs-cache/tcp/5001`) /dns/ipfs-cache/tcp/5001
 ? Value for param `TNBOX_SCRIPT_CID` of type `string`? (Default is `QmdcXSthqb89VF3CwtFXYHiSVZTCrggWPsDzyFSs69Cezg`) QmdcXSthqb89VF3CwtFXYHiSVZTCrggWPsDzyFSs69Cezg
-TaskRun started: zcashd-build-tnb-run-zfxmd
+Taskrun started: zcashd-build-tnb-run-jxbhsIn order to track the taskrun progress run:
+tkn taskrun logs zcashd-build-tnb-run-jxbhs -f -n default
 ```
 
 
@@ -46,5 +49,29 @@ Watch either the pod logs or task status on the Tekton dashboard.
 ```
 tkn taskrun logs zcashd-build-tnb-run-zfxmd -f -n default
 ```
-Prodcues output like:
+Produces output like:
+```
+build-with-new-magic-numbers] make[2]: Leaving directory '/workspace/source/src'
+[build-with-new-magic-numbers] make[1]: Leaving directory '/workspace/source/src'
+[build-with-new-magic-numbers] Making all in doc/man
+[build-with-new-magic-numbers] make[1]: Entering directory '/workspace/source/doc/man'
+[build-with-new-magic-numbers] make[1]: Nothing to be done for 'all'.
+[build-with-new-magic-numbers] make[1]: Leaving directory '/workspace/source/doc/man'
+[build-with-new-magic-numbers] make[1]: Entering directory '/workspace/source'
+[build-with-new-magic-numbers] make[1]: Nothing to be done for 'all-am'.
+[build-with-new-magic-numbers] make[1]: Leaving directory '/workspace/source'
+[build-with-new-magic-numbers] + tar --strip-components 3 -zvcf ./zcashd-tnb-artifacts-.tgz /workspace/source/src/zcashd /workspace/source/src/zcash-cli /workspace/source/src/zcash-gtest /workspace/source/src/zcash-tx
+[build-with-new-magic-numbers] /workspace/source/src/zcashd
+[build-with-new-magic-numbers] tar: Removing leading `/' from member names
+[build-with-new-magic-numbers] /workspace/source/src/zcash-cli
+[build-with-new-magic-numbers] tar: Removing leading `/' from hard link targets
+[build-with-new-magic-numbers] /workspace/source/src/zcash-gtest
+[build-with-new-magic-numbers] /workspace/source/src/zcash-tx
+[build-with-new-magic-numbers] + ipfs --api /dns/ipfs-cache/tcp/5001 add --quieter ./zcashd-tnb-artifacts-.tgz
+[build-with-new-magic-numbers] + tee /tekton/results/PIN_ADDED
+[build-with-new-magic-numbers] QmTu6kgWwSS8CjzYJUoQJ79sytF7QQcQC9J3gkaQdwJe2d
+```
+To retrieve this bundle to update local configmap CIDs:
+```
+ipfs --api=/ip4/127.0.0.1/tcp/5002 get /ipfs/QmTu6kgWwSS8CjzYJUoQJ79sytF7QQcQC9J3gkaQdwJe2d -o zcashd-tnb-artifacts-<insertshortsha>.tgz
 ```


### PR DESCRIPTION
Update zcash binary to v4.1.1 to allow test net in a box to deploy valid peers that aren't EOS